### PR TITLE
Feature/sdl 0293 enable oem exclusive apps support

### DIFF
--- a/docs/BasicCommunication/GetSystemInfo/index.md
+++ b/docs/BasicCommunication/GetSystemInfo/index.md
@@ -36,6 +36,7 @@ This RPC has no additional parameter requirements
 |ccpu_version|String|true|maxlength: 500|
 |language|[Common.Language](../../common/enums/#language)|true||
 |wersCountryCode|String|true|maxlength: 500|
+|systemHardwareVersion|String|false|maxlength: 500|
 
 ### Sequence Diagrams
 

--- a/docs/VehicleInfo/GetVehicleType/index.md
+++ b/docs/VehicleInfo/GetVehicleType/index.md
@@ -17,6 +17,12 @@ This RPC has no additional parameter requirements
 
 ### Response
 
+!!! note
+
+In case HMI responds with incomplete `VehicleType` (with no `make` value), the vehicle type filtering will not work on app side.
+
+!!!
+
 #### Parameters
 
 |Name|Type|Mandatory|Additional|


### PR DESCRIPTION
Provides the information for #[SDL-0293 Enable OEM exclusive apps support](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0293-vehicle-type-filter.md)

This PR is **[ready]** for review.

### Summary
* Add systemHardwareVersion param to GetSystemInfo response

* Add note to GetVehicleType index.md

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
